### PR TITLE
Two-tier approach to overcome GitHub permission restriction

### DIFF
--- a/.github/workflows/caller-corevalidation.yml
+++ b/.github/workflows/caller-corevalidation.yml
@@ -1,0 +1,27 @@
+name: Caller CoreValidation
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    paths:
+      - .github/workflows/caller-corevalidation.yml
+      - CMSIS/Core/**/*
+      - CMSIS/Core_A/**/*
+      - CMSIS/CoreValidation/**/*
+      - Device/ARM/**/*
+  workflow_dispatch:
+
+jobs:
+  upload_pr_number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo -n $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/corevalidation.yml
+++ b/.github/workflows/corevalidation.yml
@@ -1,26 +1,44 @@
+# This workflow is triggered whenever "Caller CoreValidation" workflow is completed (which is called by PR).
+# This workflow ideally should be triggered also by PR, but forked PR has limited permissions which does not
+# allow to use `configure-aws-credentials` actions and using secrets.
+# It will update its status back to the caller PR as "CoreValidation" check name
 name: CoreValidation
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    paths:
-      - .github/workflows/corevalidation.yml
-      - CMSIS/Core/**/*
-      - CMSIS/Core_A/**/*
-      - CMSIS/CoreValidation/**/*
-      - Device/ARM/**/*
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Caller CoreValidation
+    types:
+      - completed
 
 # The env variables relate to an ARM AWS account for CMSIS_5
 # If you are forking CMSIS_5 repo, please use your own info.
 env:
-  AWS_ASSUME_ROLE: arn:aws:iam::720528183931:role/Proj-vht-assume-role
-  AWS_DEFAULT_REGION: eu-west-1
-  AWS_IAM_PROFILE: Proj-vht-limited-actions
-  AWS_S3_BUCKET_NAME: gh-cmsis-5
-  AWS_SECURITY_GROUP_ID: sg-03afe5ec007b4bcb0
-  AWS_SUBNET_ID: subnet-025b7baebd743a68b
+  AWS_ASSUME_ROLE: ${{ secrets.AWS_ASSUME_ROLE }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
+  AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+  AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
+  AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
+
 jobs:
+  set_pending_status_to_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set a pending status to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "pending",
+              "context": "CoreValidation",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail
+
   ci_test:
     runs-on: ubuntu-latest
     permissions:
@@ -78,3 +96,43 @@ jobs:
       with:
         name: EventFile
         path: ${{ github.event_path }}
+
+  set_success_status_to_pr:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    if: ${{ success() }}
+    steps:
+      - name: Set success status to the PR
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "success",
+              "context": "CoreValidation",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail
+
+  set_failure_status_to_pr:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    if: ${{ failure() }}
+    steps:
+      - name: Set failure status to the PR
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "failure",
+              "context": "CoreValidation",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail


### PR DESCRIPTION
Using a two-tier approach to overcome GitHub permission restriction on pull requested-based runs.

The caller-corevalidation.yml is triggered by PRs (with limited permission if forked), it collects PR number to be passed to the called corevalidation.yml (this run has  full permissions, e.g. to assume-role and consume secrets).

The corevalidation workflow will feedback on its status to the PR with a "CoreValidation" check name.

Caveat: The corevalidation.yml code is, by GH design, run from the base branch, not from the PR. So, changes on integration-test.yml file only take effect when merged to the base branch (e.g. main)